### PR TITLE
Add event capabilities.

### DIFF
--- a/capabilities.md
+++ b/capabilities.md
@@ -151,6 +151,7 @@ Relic.
   | ------         | ----      | -----                    |
   | `eventType`    | string    | _required_               |
   | `timestamp`    | timestamp | _required_, but the SDK should provide a default value of the current time     |
+  | `attributes` | dictionary/map/hash | A map of key/value pairs associated with this event.  Values can be a string, numeric, or boolean. |
 
 ### Event Batch
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -150,7 +150,7 @@ Relic.
   | field          | type      | notes                    |
   | ------         | ----      | -----                    |
   | `eventType`    | string    | _required_               |
-  | `timestamp`    | timestamp | _required_               |
+  | `timestamp`    | timestamp | _required_, but the SDK should provide a default value of the current time     |
 
 ### Event Batch
 

--- a/capabilities.md
+++ b/capabilities.md
@@ -128,6 +128,34 @@ The SDK must allow setting all of these fields on a span:
 
   A span batch is a [batch](#batches) that contains only spans.
 
+## Events
+
+The Telemetry SDK implements an abstraction for sending custom events that
+follows the data model convention for spans and metrics.
+
+SDKs sending events must allow for the specification of "common" attributes.
+Common attributes will be attached to every event individually inside of the
+SDK since the current Event API does not allow specification of common
+attributes via the API payload.
+
+For detailed information about the Event API, please see the [public documentation](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/introduction-event-api).
+
+The Telemetry SDK must use the following HTTP path for the Event API:
+`/v1/accounts/events`
+
+The SDK must provide a representation of an event with the following fields.
+It must be possible to serialize this representation for transport to New
+Relic.
+
+  | field          | type      | notes                    |
+  | ------         | ----      | -----                    |
+  | `eventType`    | string    | _required_               |
+  | `timestamp`    | timestamp | _required_               |
+
+### Event Batch
+
+  An event batch is a [batch](#batches) that contains only events.
+
 ## Batches
 
 A batch is a data structure containing multiple data points of the same telemetry type.


### PR DESCRIPTION
This PR describes how Telemetry SDKs will implement sending custom events.

Details of interest:
* HTTP path for the Events API is `/v1/accounts/events`
* SDKs must implement a synthetic "common" attribute block for events to conform to the span/metric data model / API format