### PR TITLE
Remove obsolete no-op section

### DIFF
--- a/configuration-and-logging.md
+++ b/configuration-and-logging.md
@@ -18,12 +18,6 @@ SDK implementations must allow for configuration of the following options:
 5. `Audit logging enabled`
   * If audit logging is enabled, the SDK should record additional highly verbose debugging information at the `DEBUG` logging level.  The default value for this setting must be `false`.
 
-## No-op behavior
-
-When the Telemetry API is in use by customers it will lead to API calls being used (possibly extensively) throughout customer code. If the customer needs to quickly disable these API calls the SDK must provide a no-op implementation that the customer can swap in without requiring that they modify all API call sites.
-
-By providing a no-op implementation this means that any call to the Telemetry API will effectively have zero cost until a real implementation is swapped back in.
-
 # Logging
 
 SDK implementations should log troubleshooting and error information by whatever means is


### PR DESCRIPTION
As far as I know, the no-op behavior isn't implemented by any Telemetry SDK, and no implementation of this feature is planned for any Telemetry SDK. Therefore I suggest removing it.

I think this premise that the idea is based on doesn't hold up:
> When the Telemetry API is in use by customers it will lead to API calls being used (possibly extensively) throughout customer code.

It's contradicted by this section in the README.md:
> The Telemetry SDK's primary use case is:                                        
>                                                                            
> A user has telemetry data: metrics, traces, logs, or events, that have already been created (for example: from Prometheus or OpenTelemetry), and they want to get them into New Relic easily and efficiently.