### PR TITLE
Remove broken links and other minor cleanup

### DIFF
--- a/capabilities.md
+++ b/capabilities.md
@@ -9,7 +9,7 @@ about the Metric model, please see the [public documentation](https://docs.newre
 
 The SDK must support two primary use cases:
 1. It must be possible to construct them with
-   pre-computed values, and the SDK must be capable of serializing them into the for
+   pre-computed values, and the SDK must be capable of serializing them for
    transport to New Relic.
 2. The SDK must provide aggregation functionality for each of New Relic's supported metric
    types.  The appropriate aggregation function is different for each metric type.
@@ -30,7 +30,7 @@ All metric types have these common fields:
 
 #### `Count`
 
-  In addition to the common fields, the count metric type has the following field:
+  In addition to the common fields, the count metric type has the following fields:
 
   | field | type | notes |
   | ----- | ---- | ----- |
@@ -176,7 +176,7 @@ possible to serialize this representation for transport to New Relic.transport
   | field          | type      | notes                    |
   | ------         | ----      | -----                    |
   | `timestamp`    | timestamp | _required_, but the SDK should provide a default value of the current time  |
-  | `message`      | string    | technical _optional_, but strongly suggested  |
+  | `message`      | string    | technically _optional_, but strongly suggested  |
   | `attributes`   | dictionary/map/hash | A map of key/value pairs associated with this event.  Values can be a string, numeric, or boolean. |
 
 Note: There are a variety of additional standard attributes that may be provided for, based on the

--- a/validation.md
+++ b/validation.md
@@ -2,10 +2,6 @@
 
 The New Relic telemetry ingest pipeline performs lightweight synchronous validation on all inbound requests as well as a more thorough asynchronous validation on the payload contents. SDK implementations **SHOULD** only perform minimal validation on input data as noted below.
 
-## MELT ingest pipeline
-
-![image](MELT-ingest-pipeline.png)
-
 ## SDK validation
 
 In an effort to keep SDK complexity low the SDK implementation **MUST** limit its validation to the bare minimum required to be safe for clients. The SDK **MUST NOT** throw exceptions or errors on data ingest unless the caller is explicitly notified of the possibility. 
@@ -18,9 +14,9 @@ For example, in languages where `NaN` or `Infinity` can be represented these val
 
 The New Relic telemetry ingest pipline has its own set of limits and restrictions on inbound data that it enforces at various stages of data ingest.
 
-Initial lightweight validation of inbound requests occur synchronously and result in [Response codes](#response-codes) being sent back to the SDK to indicate failed validation.
+Initial lightweight validation of inbound requests occur synchronously and result in [Response codes](communication.md#response-codes) being sent back to the SDK to indicate failed validation.
 
-A more thorough validation of payload contents occurs asynchronously the SDK will not be directly notified of this failure. Instead, a custom event named `NrIntegrationError` is emitted to the account that includes data about the failure. Some potential failure cases are listed below:
+A more thorough validation of payload contents occurs asynchronously. If this fails, the SDK will not be directly notified. Instead, a custom event named `NrIntegrationError` is emitted to the account that includes data about the failure. Some potential failure cases are listed below:
 
 | Failure | Discard data point | Discard payload |
 | ------- | -------------------| ----------------|
@@ -31,4 +27,4 @@ A more thorough validation of payload contents occurs asynchronously the SDK wil
 
 ### New Relic storage constraints
 
-The New Relic backend has limits on the size and number of attributes that may be stored for data points. Detailed explanations of these limits can be found here: [Metric API Limits](https://docs.google.com/document/d/1YQniWHGxO6WcOk3AQLOzchiMksNJ3zCY_aPo8Zk8des/edit#heading=h.bp5nzjycedpw)
+The New Relic backend has limits on the size and number of attributes that may be stored for data points. When these limits are exceeded, an `NrIntegrationError` is emitted to the account.


### PR DESCRIPTION
This PR performs some minor cleanup in a couple of files.

In capabilities.md:
* Fix a few typos.

In validation.md:
* Remove a link to a missing diagram that is not critical to the page.
* Fix the link to the response codes table.
* Split and reword a run-on sentence.
* Remove a link to an internal (and out of date) doc and replace it with wording about what happens when limits are exceeded.