### PR TITLE
Add backoff max to configuration section

### DIFF
--- a/configuration-and-logging.md
+++ b/configuration-and-logging.md
@@ -11,6 +11,7 @@ SDK implementations must allow for configuration of the following options:
 4. `Failed request retrying`
   * It must be possible to configure the _backoff factor_, that is the amount of time to wait
     after a failed request before attempting to send the request again.
+  * It must also be possible to configure _backoff max_, the maximum amount of time to wait between retrying the request.
   * It must also be possible to configure the _max retries_.
     See [communication backoff](./communication.md#graceful-degradation).
 5. `Logging`


### PR DESCRIPTION
The graceful [degradation section in Communication](https://github.com/newrelic/newrelic-telemetry-sdk-specs/blob/master/communication.md#graceful-degradation) refers to configurable values used to calculate backoff intervals, however _backoff max_ is not actually listed in the configuration section, unlike the others. 

For clarity, I've added _backoff max_ to the configuration section in a similar way to the others related to that calculation. 